### PR TITLE
Fix index file reference

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   "name": "@nandorojo/heroicons",
   "version": "0.0.4",
   "main": "lib/commonjs/index.js",
-  "react-native": "src/index.ts",
+  "react-native": "src/index.tsx",
   "module": "lib/module/index.js",
   "types": "index.d.ts",
   "scripts": {


### PR DESCRIPTION
### Changes Made:
- Updated `react-native` reference in `package.json` from `src/index.ts` to `src/index.tsx`.

### Reasoning:
I'm currently using this library in my mono-repo project using Solito and the Metro Bundler keep reporting this error 
```
[TestApp] Metro has encountered an error: While trying to resolve module `@nandorojo/heroicons` from file
`/haUser/app/(main)/_layout.tsx`, the package
`/haUser/node_modules/@nandorojo/heroicons/package.json` was successfully found. However, this package itself specifies a
`main` module field that could not be resolved (`/haUser/node_modules/@nandorojo/heroicons/src/index.ts`. Indeed, none of these
files exist:
```

And making this change in the `node_modules` fixes it and my app runs fine now.